### PR TITLE
Careful microoptimisations for 2x performance improvement

### DIFF
--- a/src/corefunctionality.jl
+++ b/src/corefunctionality.jl
@@ -2,8 +2,7 @@
 const pool = WeakKeyDict{String, Void}()
 
 
-
-@inline function intern!(wkd::WeakKeyDict{K}, key::K) ::K where K
+@inline function intern!(wkd::WeakKeyDict{K}, key)::K where K
     kk::K = convert(K, key)
 
     lock(wkd.lock)
@@ -14,7 +13,7 @@ const pool = WeakKeyDict{String, Void}()
         @inbounds found_key = wkd.ht.keys[index]
         unlock(wkd.lock)
 
-        return found_key.value # a strong ref
+        return found_key.value # a strong ref #TODO workout away to make this type stable
     else
         # Not found, so add it,
         # and mark it as a reference we track to delete!

--- a/src/corefunctionality.jl
+++ b/src/corefunctionality.jl
@@ -3,6 +3,8 @@ const pool = WeakKeyDict{String, Void}()
 # This forces the type to be inferred (I don't know that the @noinline is reqired or even good)
 @noinline getvalue(::Type{K}, wk) where K = wk.value::K
 
+
+# NOTE: This code is carefully optimised. Do not tweak it (for readability or otherwise) without benchmarking
 @inline function intern!(wkd::WeakKeyDict{K}, key)::K where K
     kk::K = convert(K, key)
 


### PR DESCRIPTION
This could do with some careful review.

It halves the time of the constructor (both for found, and not found),
and overall the tests suite runs 30% faster.

