### PR TITLE
Add intern(::Type, ::AbstractString) to choose custom return type

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+WeakRefStrings 0.4.4

--- a/test/all_kinds_of_types.jl
+++ b/test/all_kinds_of_types.jl
@@ -7,12 +7,16 @@ using InternedStrings
     @test !(ex1==="ex")
     ex2 = intern("ex")
     @test ex1===ex2
+    ex3 = intern(String, "ex")
+    @test ex1===ex3
 
 
 
     @testset "type inference" begin
         @test ex1 isa String
+        @test ex2 isa String
         @inferred intern("ex")
+        @inferred intern(String, "ex")
     end
 end
 
@@ -21,15 +25,31 @@ end
 @testset "SubString" begin
     aa1, bb1, cc1 = intern.(split("aa bb cc"))
     aa2, bb2, cc2 = intern.(split("aa bb cc"))
+    aa3, bb3, cc3 = intern.(String, split("aa bb cc"))
 
     @test bb1=="bb"
     @test !(bb1==="bb")
     @test bb1===bb2
+    @test bb1===bb3
 
     @testset "type inference" begin
         @test intern(split("aa bb cc")[1]) isa String
         @inferred intern(split("aa bb cc")[1])
+        @test intern(String, split("aa bb cc")[1]) isa String
+        @inferred intern(String, split("aa bb cc")[1])
     end
+end
+
+@testset "WeakRefString" begin
+    using WeakRefStrings
+    s1 = "ex"
+    s2 = "ex"
+    ex1 = @inferred intern(String, WeakRefString(Vector{UInt8}(s1)))
+    @test ex1=="ex"
+    @test !(ex1===s1)
+    @test ex1 isa String
+    ex2 = @inferred intern(String, WeakRefString(Vector{UInt8}(s2)))
+    @test ex1===ex2
 end
 
 #== Uncomment when https://github.com/JuliaLang/julia/issues/26939  is fixed


### PR DESCRIPTION
This allows returning standard String values from custom `AbstractString` values, avoiding a copy. This is particularly useful for `WeakRefString`. To achieve this, only call `convert` when the string is not found in the pool.

As discussed with @quinnj, this should allow CSV.jl to use InternedStrings and return `Vector{String}` columns with interned strings instead of `WeakRefStringArray`/`StringArray` by default.

I can add `WeakRefString` tests if you want.