### PR TITLE
Fix most deprecations on Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.52

--- a/src/InternedStrings.jl
+++ b/src/InternedStrings.jl
@@ -7,17 +7,16 @@ Licensed under MIT License, see LICENSE.md
 """
 module InternedStrings
 
+using Compat
+
 export @i_str, intern
 
 Base.@deprecate_binding(InternedString, String, true)
 
 @static if VERSION < v"0.7.0-DEV"
-    const Nothing = Void
     const ht_keyindex2! = Base.ht_keyindex2
-    add_finalizer(fun::Function, obj) = Base.finalizer(obj, fun)
 else
     using Base: ht_keyindex2!
-    const add_finalizer = Base.finalizer
 end
 
 ########################
@@ -43,7 +42,7 @@ end
         # Not found, so add it,
         # and mark it as a reference we track to delete!
         kk::K = convert(K, key)
-        add_finalizer(wkd.finalizer, kk) # finalizer is set on the strong ref
+        @compat finalizer(wkd.finalizer, kk) # finalizer is set on the strong ref
         @inbounds Base._setindex!(wkd.ht, nothing, WeakRef(kk), -index)
         unlock(wkd.lock)
         return kk # Return the strong ref

--- a/test/all_kinds_of_types.jl
+++ b/test/all_kinds_of_types.jl
@@ -38,6 +38,7 @@ end
     s1 = "ex"
     s2 = "ex"
     ex1 = @inferred intern(String, WeakRefString(unsafe_wrap(Vector{UInt8}, s1)))
+    @test ex1=="ex"
     @test !addr_eq(ex1, s1)
     @test ex1 isa String
     ex2 = @inferred intern(String, WeakRefString(unsafe_wrap(Vector{UInt8}, s2)))


### PR DESCRIPTION
The main change is that strings are now `=== `even if they point to different memory areas, so we need to use `pointer` to check whether they are really the same. `object_id` is also no longer a meaningful test for strings.

I tried changing the `object_id` testset to use big floats instead of strings, but it triggers a crash when closing Julia. Reproducer:
```julia
@testset "ID check" begin let
    empty!(InternedStrings.pool)

    a = BigFloat(π)
    target_id = objectid(a)

    a = intern(a)
    @test objectid(a) == target_id

    b = BigFloat(π)
    @test objectid(b) != target_id
    b = intern(b)
    @test objectid(b)== target_id

    @test objectid(intern(BigFloat(π))) == target_id

#    use(a,b)
end end
```